### PR TITLE
External exec

### DIFF
--- a/lib/webhooks/src/request-handlers/post.js
+++ b/lib/webhooks/src/request-handlers/post.js
@@ -83,6 +83,7 @@ class PostHandler extends BaseHandler {
         log.trace('Creating webhook msg from request');
 
         const msg = newEmptyMessage();
+        msg.metadata.externalExecId = this.getRequestId();
 
         _.each(REQUEST_FIELDS, (key) => {
             if (key === 'body') {

--- a/lib/webhooks/src/request-handlers/post.js
+++ b/lib/webhooks/src/request-handlers/post.js
@@ -83,10 +83,10 @@ class PostHandler extends BaseHandler {
         log.trace('Creating webhook msg from request');
 
         const msg = newEmptyMessage();
-        msg.metadata.externalExecId = this.getRequestId();
         msg.metadata.source = {
-            id: 'webhooks',
-            type: 'webhook'
+            name: 'webhooks',
+            type: 'webhook',
+            externalExecId: this.getRequestId()
         };
 
         _.each(REQUEST_FIELDS, (key) => {

--- a/lib/webhooks/src/request-handlers/post.js
+++ b/lib/webhooks/src/request-handlers/post.js
@@ -84,6 +84,10 @@ class PostHandler extends BaseHandler {
 
         const msg = newEmptyMessage();
         msg.metadata.externalExecId = this.getRequestId();
+        msg.metadata.source = {
+            id: 'webhooks',
+            type: 'webhook'
+        };
 
         _.each(REQUEST_FIELDS, (key) => {
             if (key === 'body') {

--- a/services/scheduler/src/SchedulePublisher.js
+++ b/services/scheduler/src/SchedulePublisher.js
@@ -24,10 +24,10 @@ class OIH_SchedulePublisher extends SchedulePublisher {
           },
           metadata: {
             source: {
-              id: 'scheduler',
+              name: 'scheduler',
               type: 'scheduler',
+              externalExecId: generateRequestId(),
             },
-            externalExecId: generateRequestId(),
           },
         },
       },

--- a/services/scheduler/src/SchedulePublisher.js
+++ b/services/scheduler/src/SchedulePublisher.js
@@ -1,5 +1,6 @@
 const { SchedulePublisher } = require('@openintegrationhub/scheduler');
 const { Event } = require('@openintegrationhub/event-bus');
+const cronParser = require('cron-parser');
 
 class OIH_SchedulePublisher extends SchedulePublisher {
   constructor({ eventBus }) {
@@ -7,6 +8,8 @@ class OIH_SchedulePublisher extends SchedulePublisher {
     this._eventBus = eventBus;
   }
   async scheduleFlow(flow) {
+    const interval = cronParser.parseExpression(flow.cron);
+    const nextSheduledTimestamp = interval.next();
     const event = new Event({
       headers: {
         name: 'flow.execute',
@@ -14,10 +17,32 @@ class OIH_SchedulePublisher extends SchedulePublisher {
       },
       payload: {
         flow,
+        msg: {
+          data: {
+            sheduledTimestamp: new Date().toISOString(),
+            nextSheduledTimestamp,
+          },
+          metadata: {
+            source: {
+              id: 'scheduler',
+              type: 'scheduler',
+            },
+            externalExecId: generateRequestId(),
+          },
+        },
       },
     });
     this._eventBus.publish(event);
   }
+}
+
+function generateRequestId() {
+  // NOTE the result should be in the same format as provided by proxy in from of this server (nginx)
+  const numbers = [];
+  for (let i = 0; i < 32; i++) {
+      numbers[i] = Math.floor(Math.random() * 16).toString(16);
+  }
+  return numbers.join('');
 }
 
 module.exports = OIH_SchedulePublisher;


### PR DESCRIPTION
**What has changed?**

- Webhook requestId in the response object always passed into flow
- Scheduler always passes unique ID the same as the webhook service
- Add source metadata to webhhooks and scheduler payload
- Add scheduler related data to the scheduler payload

**Does a specific change require especially careful review?**

N/A

**What is still open or a known issue?**
N/A

**Release Notes**
Same as what has changed