### PR TITLE
Add prefetch count environment variable to better recover from large queues

### DIFF
--- a/lib/event-bus/src/RabbitMqTransport.js
+++ b/lib/event-bus/src/RabbitMqTransport.js
@@ -143,6 +143,7 @@ class RabbitMqTransport extends Transport {
             assert(this._connection, 'Can`t create a channel without a connection');
             if (!this._subscribeChannel) {
                 this._subscribeChannel = await this._connection.createChannel();
+                this._subscribeChannel.prefetch(process.env.PREFETCH_COUNT || 1);
             }
             return this._subscribeChannel;
         } catch (err) {

--- a/lib/event-bus/src/RabbitMqTransport.js
+++ b/lib/event-bus/src/RabbitMqTransport.js
@@ -143,7 +143,7 @@ class RabbitMqTransport extends Transport {
             assert(this._connection, 'Can`t create a channel without a connection');
             if (!this._subscribeChannel) {
                 this._subscribeChannel = await this._connection.createChannel();
-                this._subscribeChannel.prefetch(process.env.PREFETCH_COUNT || 1000);
+                await this._subscribeChannel.prefetch(process.env.PREFETCH_COUNT || 1000);
             }
             return this._subscribeChannel;
         } catch (err) {

--- a/lib/event-bus/src/RabbitMqTransport.js
+++ b/lib/event-bus/src/RabbitMqTransport.js
@@ -143,7 +143,7 @@ class RabbitMqTransport extends Transport {
             assert(this._connection, 'Can`t create a channel without a connection');
             if (!this._subscribeChannel) {
                 this._subscribeChannel = await this._connection.createChannel();
-                this._subscribeChannel.prefetch(process.env.PREFETCH_COUNT || 1);
+                this._subscribeChannel.prefetch(process.env.PREFETCH_COUNT || 1000);
             }
             return this._subscribeChannel;
         } catch (err) {

--- a/lib/ferryman/lib/amqp.js
+++ b/lib/ferryman/lib/amqp.js
@@ -96,7 +96,7 @@ class Amqp {
         }
         let result;
         try {
-            this.subscribeChannel.prefetch(this.settings.RABBITMQ_PREFETCH_SAILOR);
+            await this.subscribeChannel.prefetch(this.settings.RABBITMQ_PREFETCH_SAILOR);
 
             result = await this.subscribeChannel.consume(
                 queueName, this.decryptMessage.bind(this, callback)

--- a/services/component-orchestrator/src/ComponentOrchestratorApp.js
+++ b/services/component-orchestrator/src/ComponentOrchestratorApp.js
@@ -29,7 +29,7 @@ class ComponentOrchestratorApp extends App {
 
         const channel = await amqp.getConnection().createChannel();
 
-        channel.prefetch(process.env.PREFETCH_COUNT || 1000);
+        await channel.prefetch(process.env.PREFETCH_COUNT || 1000);
 
         channel.on('error', function (err) {
             logger.fatal(err, 'RabbitMQ channel error');

--- a/services/component-orchestrator/src/ComponentOrchestratorApp.js
+++ b/services/component-orchestrator/src/ComponentOrchestratorApp.js
@@ -29,7 +29,7 @@ class ComponentOrchestratorApp extends App {
 
         const channel = await amqp.getConnection().createChannel();
 
-        channel.prefetch(process.env.PREFETCH_COUNT || 1);
+        channel.prefetch(process.env.PREFETCH_COUNT || 1000);
 
         channel.on('error', function (err) {
             logger.fatal(err, 'RabbitMQ channel error');

--- a/services/component-orchestrator/src/ComponentOrchestratorApp.js
+++ b/services/component-orchestrator/src/ComponentOrchestratorApp.js
@@ -29,6 +29,8 @@ class ComponentOrchestratorApp extends App {
 
         const channel = await amqp.getConnection().createChannel();
 
+        channel.prefetch(process.env.PREFETCH_COUNT || 1);
+
         channel.on('error', function (err) {
             logger.fatal(err, 'RabbitMQ channel error');
             process.exit(1);

--- a/services/scheduler/src/SchedulerApp.js
+++ b/services/scheduler/src/SchedulerApp.js
@@ -18,7 +18,7 @@ class SchedulerApp extends App {
         await amqp.start();
         this._initHealthcheckApi(config.get('LISTEN_PORT'));
         const channel = await amqp.getConnection().createChannel();
-        channel.prefetch(process.env.PREFETCH_COUNT || 1);
+        channel.prefetch(process.env.PREFETCH_COUNT || 100);
         const queueCreator = new QueueCreator(channel);
 
         const mongooseOptions = {

--- a/services/scheduler/src/SchedulerApp.js
+++ b/services/scheduler/src/SchedulerApp.js
@@ -18,7 +18,7 @@ class SchedulerApp extends App {
         await amqp.start();
         this._initHealthcheckApi(config.get('LISTEN_PORT'));
         const channel = await amqp.getConnection().createChannel();
-        channel.prefetch(process.env.PREFETCH_COUNT || 100);
+        await channel.prefetch(process.env.PREFETCH_COUNT || 100);
         const queueCreator = new QueueCreator(channel);
 
         const mongooseOptions = {

--- a/services/scheduler/src/SchedulerApp.js
+++ b/services/scheduler/src/SchedulerApp.js
@@ -18,6 +18,7 @@ class SchedulerApp extends App {
         await amqp.start();
         this._initHealthcheckApi(config.get('LISTEN_PORT'));
         const channel = await amqp.getConnection().createChannel();
+        channel.prefetch(process.env.PREFETCH_COUNT || 1);
         const queueCreator = new QueueCreator(channel);
 
         const mongooseOptions = {


### PR DESCRIPTION
**What has changed?**

- Added RabbitMQ prefetch count environment variable for consumer channels. This will allow for easier recovery from queue backups and allow a service to fully start in that scenario.

**Does a specific change require especially careful review?**
- The default value may limit the processing throughput which was unconstrained before

**What is still open or a known issue?**
N/A

**Release Notes**
Added configuration for RabbitMQ prefetch count https://amqp-node.github.io/amqplib/channel_api.html#channel_prefetch
