### PR TITLE
Expand auth client types

### DIFF
--- a/services/secret-service/src/constant/index.js
+++ b/services/secret-service/src/constant/index.js
@@ -10,6 +10,7 @@ module.exports = {
         OA1_TWO_LEGGED: 'OA1_TWO_LEGGED',
         OA1_THREE_LEGGED: 'OA1_THREE_LEGGED',
         OA2_AUTHORIZATION_CODE: 'OA2_AUTHORIZATION_CODE',
+        OA2_PASSWORD: 'OA2_PASSWORD',
         SIMPLE: 'SIMPLE',
         MIXED: 'MIXED',
         SESSION_AUTH: 'SESSION_AUTH',
@@ -46,6 +47,7 @@ module.exports = {
             'username',
             'payload',
             'inputFields',
+            'consumerSecret',
         ],
         // subset of SENSITIVE_FIELDS
         OBJECT_FIELDS: [

--- a/services/secret-service/src/model/Secret/index.js
+++ b/services/secret-service/src/model/Secret/index.js
@@ -107,6 +107,25 @@ module.exports = {
     })),
     [OA1_TWO_LEGGED]: Secret.discriminator(`S_${OA1_TWO_LEGGED}`, new Schema({
         value: {
+            consumerKey: {
+                type: String,
+                required: true,
+            },
+            consumerSecret: {
+                type: String,
+                required: true,
+            },
+            signatureMethod: {
+                type: String,
+                required: true,
+            },
+            version: {
+                type: String,
+                default: '1.0',
+            },
+            accessToken: String,
+            accessTokenSecret: String,
+            realm: String,
             expiresAt: String,
         },
     })),


### PR DESCRIPTION
**What has changed?**

- Secret type of `OA1_TWO_LEGGED` expanded to include all needed fields
- `consumerSecret` added to list of sensitive fields automatically encrypted by OIH

**Does a specific change require especially careful review?**

As far as I am aware the `OA1_TWO_LEGGED` secret type was unused, so changes here should not affect anything.

The addition of `consumerSecret` to the sensitive fields means that if any existing secrets have this field they will be corrupted when accessed (OIH will attempt to decrypt them, even though they have not been encrypted already). To reduce this risk we could namespace the field to something less likely to already be in use, like `OA1_consumerSecret`.

**What is still open or a known issue?**
This does not address the issue of being able to generate OAuth1 secrets - the access token still has to be generated manually and included in the secret at the time of creation.

**Release Notes**

Add support for OAuth1 secrets
