### PR TITLE
update OA1TwoLeggedSecret documentation

### DIFF
--- a/services/secret-service/doc/openapi.json
+++ b/services/secret-service/doc/openapi.json
@@ -1120,8 +1120,39 @@
       "OA1TwoLeggedSecret": {
         "type": "object",
         "properties": {
-          "expiresAt": {
+          "consumerKey": {
+            "type": "string",
+            "required": true,
+            "description": "The Consumer Key may also be known as 'Client Key', 'Consumer Identifier', or 'API Key'"
+          },
+          "consumerSecret": {
+            "type": "string",
+            "required": true,
+            "description": "The Consumer Secret may also be known as 'Client Secret', 'Shared Secret', or 'API Secret'"
+          },
+          "signatureMethod": {
+            "type": "string",
+            "required": true,
+            "description": "HMAC-SHA1, HMAC-SHA256, etc."
+          },
+          "version": {
+            "type": "string",
+            "default": "1.0"
+          },
+          "accessToken": {
             "type": "string"
+          },
+          "accessTokenSecret": {
+            "type": "string",
+            "description": "Optional depending on the requirements of the endpoint, may also be called 'Token Secret'"
+          },
+          "realm": {
+            "type": "string",
+            "description": "Optional depending on the requirements of the endpoint"
+          },
+          "expiresAt": {
+            "type": "string",
+            "description": "OAuth1 access tokens do not typically expire, but this field may be useful for some implementations"
           }
         }
       },


### PR DESCRIPTION
**What has changed?**

Updated documentation for the OAuth1 Two Legged Secret type.

**Does a specific change require especially careful review?**

No

**Release Notes**

Updated documentation for the OAuth1 Two Legged Secret type