### PR TITLE
Add oauth2 password

### DIFF
--- a/services/secret-service/doc/openapi.json
+++ b/services/secret-service/doc/openapi.json
@@ -566,6 +566,9 @@
           "$ref": "#/components/schemas/MutableOA2AuthorizationCodeClient"
         }, {
           "$ref": "#/components/schemas/MutableSessionAuthClient"
+        }, {
+          "$ref": "#/components/schemas/MutableOA2PasswordClient"
+        
         } ],
         "discriminator": {
           "propertyName": "type",
@@ -573,6 +576,7 @@
             "OA1_TWO_LEGGED": "#/components/schemas/MutableOA1TwoLeggedClient",
             "OA1_THREE_LEGGED": "#/components/schemas/MutableOA1ThreeLeggedClient",
             "OA2_AUTHORIZATION_CODE": "#/components/schemas/MutableOA2AuthorizationCodeClient",
+            "OA2_PASSWORD": "#/components/schemas/MutableOA2PasswordClient",
             "SESSION_AUTH": "#/components/schemas/MutableSessionAuthClient"
           }
         }
@@ -746,6 +750,58 @@
           }
         }
       },
+      "MutableOA2PasswordClient" : {
+        "required" : [ "name", "owners", "type", "clientId", "clientSecret", "endpoints"],
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          },
+          "owners" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Owner"
+            }
+          },
+          "type" : {
+            "type" : "string",
+            "enum" : [ "OA1_TWO_LEGGED", "OA1_THREE_LEGGED", "OA2_AUTHORIZATION_CODE", "SESSION_AUTH", "OA2_PASSWORD" ]
+          },
+          "clientId" : {
+            "type" : "string",
+            "example": "292085223830.apps.googleusercontent.com"
+          },
+          "clientSecret" : {
+            "type" : "string",
+            "example": "F4B82757C43741436B195B28AF4AF"
+          },
+          "endpoints" : {
+            "$ref" : "#/components/schemas/MutableOA2PasswordClient_endpoints"
+          },
+          "predefinedScope": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "incluceCredentialsInHeader": {
+            "type": "boolean",
+            "description": "If true, the credentials will be sent in the header instead of the body.",
+            "default": false
+          }
+        }
+      },
+      "MutableOA2PasswordClient_endpoints" : {
+        "type" : "object",
+        "required": ["token"],
+        "properties" : {
+          "token" : {
+            "type" : "string"
+          }
+        }
+      },
       "MutableSessionAuthClient": {
         "required": ["name", "owners", "type", "fields", "endpoints"],
         "properties": {
@@ -803,6 +859,8 @@
           "$ref" : "#/components/schemas/OA2AuthorizationCodeClient"
         }, {
           "$ref": "#/components/schemas/SessionAuthClient"
+        }, {
+          "$ref": "#/components/schemas/OA2PasswordClient"
         } ],
         "discriminator": {
           "propertyName": "type",
@@ -810,6 +868,7 @@
             "OA1_TWO_LEGGED": "#/components/schemas/MutableOA1TwoLeggedClient",
             "OA1_THREE_LEGGED": "#/components/schemas/MutableOA1ThreeLeggedClient",
             "OA2_AUTHORIZATION_CODE": "#/components/schemas/MutableOA2AuthorizationCodeClient",
+            "OA2_PASSWORD": "#/components/schemas/MutableOA2PasswordClient",
             "SESSION_AUTH": "#/components/schemas/MutableSessionAuthClient"
           }
         }
@@ -863,6 +922,30 @@
       "OA2AuthorizationCodeClient" : {
         "allOf" : [ {
           "$ref" : "#/components/schemas/MutableOA2AuthorizationCodeClient"
+        }, {
+          "required" : [ "createdAt", "_id" ],
+          "type" : "object",
+          "properties" : {
+            "_id" : {
+              "type" : "string",
+              "example": ""
+            },
+            "createdAt" : {
+              "type" : "string",
+              "description" : "Client creation time",
+              "format" : "date-time"
+            },
+            "updatedAt" : {
+              "type" : "string",
+              "description" : "Client update time",
+              "format" : "date-time"
+            }
+          }
+        } ]
+      },
+      "OA2PasswordClient" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/MutableOA2PasswordClient"
         }, {
           "required" : [ "createdAt", "_id" ],
           "type" : "object",
@@ -997,7 +1080,8 @@
                 "SESSION_AUTH": "#/components/schemas/SessionAuthSecret",
                 "OA1_TWO_LEGGED": "#/components/schemas/OA1TwoLeggedSecret",
                 "OA1_THREE_LEGGED": "#/components/schemas/OA1ThreeLeggedSecret",
-                "OA2_AUTHORIZATION_CODE": "#/components/schemas/OA2AuthorizationCodeSecret"
+                "OA2_AUTHORIZATION_CODE": "#/components/schemas/OA2AuthorizationCodeSecret",
+                "OA2_PASSWORD": "#/components/schemas/OA2PasswordSecret"
               }
             },
             "oneOf" : [ {
@@ -1014,6 +1098,8 @@
               "$ref": "#/components/schemas/OA1ThreeLeggedSecret"
             }, {
               "$ref": "#/components/schemas/OA2AuthorizationCodeSecret"
+            }, {
+              "$ref": "#/components/schemas/OA2PasswordSecret"
             } ]
           },
           "owners" : {
@@ -1174,6 +1260,37 @@
           },
           "externalId": {
             "type": "string"
+          }
+        }
+      },
+      "OA2PasswordSecret" : {
+        "required" : ["authClientId", "accessToken", "tokenType"],
+        "type" : "object",
+        "properties" : {
+          "authClientId" : {
+            "type" : "string",
+            "description" : "Id of the auth client this secret was created with"
+          },
+          "refreshToken" : {
+            "type" : "string"
+          },
+          "accessToken" : {
+            "type" : "string"
+          },
+          "tokenType": {
+            "type": "string"
+          },
+          "scope": {
+            "type": "string"
+          },
+          "expires" : {
+            "type" : "string",
+            "description" : "Date object in UTC",
+            "format" : "date-time"
+          },
+          "fullResponse": {
+            "type": "string",
+            "description": "The full success response from the token endpoint (stored encrypted)"
           }
         }
       },

--- a/services/secret-service/src/auth-flow-manager/index.js
+++ b/services/secret-service/src/auth-flow-manager/index.js
@@ -310,10 +310,8 @@ module.exports = {
             password,
         };
 
-        const selectedScope = scope || authClient.predefinedScope;
-
-        if (selectedScope) {
-            params.scope = selectedScope;
+        if (scope) {
+            params.scope = scope;
         }
 
         const headers = {};

--- a/services/secret-service/src/auth-flow-manager/index.js
+++ b/services/secret-service/src/auth-flow-manager/index.js
@@ -6,7 +6,9 @@ const { OAuth } = require('oauth');
 const logger = require('@basaas/node-logger');
 const conf = require('../conf');
 const { OA2_AUTHORIZATION_CODE, OA1_THREE_LEGGED, SESSION_AUTH } = require('../constant').AUTH_TYPE;
-const { HEADER_AUTH, BODY_AUTH, PARAMS_AUTH, FORM_AUTH } = require('../constant').AUTH_REQUEST_TYPE;
+const {
+    HEADER_AUTH, BODY_AUTH, PARAMS_AUTH, FORM_AUTH,
+} = require('../constant').AUTH_REQUEST_TYPE;
 const defaultAdapter = require('../adapter/preprocessor/default');
 
 const log = logger.getLogger(`${conf.log.namespace}/auth-flow-manager`);
@@ -82,7 +84,7 @@ async function oauthGetAuthorize({ authClient, flow }) {
 }
 
 // oauth2
-async function requestHelper(url, form) {
+async function requestHelper(url, form, headers = {}) {
     const params = new URLSearchParams();
     for (const property in form) {
         if (Object.prototype.hasOwnProperty.call(form, property)) {
@@ -105,6 +107,7 @@ async function requestHelper(url, form) {
         headers: {
             'Content-Type': 'application/x-www-form-urlencoded',
             Accept: 'application/json',
+            ...headers,
         },
         body: params,
     });
@@ -296,5 +299,32 @@ module.exports = {
         return await defaultAdapter({
             flow, authClient, secret, tokenResponse,
         });
+    },
+
+    async exchangeRequestPasswordFlow({
+        authClient, username, password, scope,
+    }) {
+        const params = {
+            grant_type: 'password',
+            username,
+            password,
+        };
+
+        const selectedScope = scope || authClient.predefinedScope;
+
+        if (selectedScope) {
+            params.scope = selectedScope;
+        }
+
+        const headers = {};
+
+        if (authClient.includeCredentialsInHeader) {
+            headers.Authorization = `Basic ${Buffer.from(`${authClient.clientId}:${authClient.clientSecret}`).toString('base64')}`;
+        } else {
+            params.client_id = authClient.clientId;
+            params.client_secret = authClient.clientSecret;
+        }
+
+        return await requestHelper(authClient.endpoints.token, params, headers);
     },
 };

--- a/services/secret-service/src/constant/index.js
+++ b/services/secret-service/src/constant/index.js
@@ -49,6 +49,7 @@ module.exports = {
             'inputFields',
             'fullResponse',
             'consumerSecret',
+            'password',
         ],
         // subset of SENSITIVE_FIELDS
         OBJECT_FIELDS: [

--- a/services/secret-service/src/constant/index.js
+++ b/services/secret-service/src/constant/index.js
@@ -10,6 +10,7 @@ module.exports = {
         OA1_TWO_LEGGED: 'OA1_TWO_LEGGED',
         OA1_THREE_LEGGED: 'OA1_THREE_LEGGED',
         OA2_AUTHORIZATION_CODE: 'OA2_AUTHORIZATION_CODE',
+        OA2_PASSWORD: 'OA2_PASSWORD',
         SIMPLE: 'SIMPLE',
         MIXED: 'MIXED',
         SESSION_AUTH: 'SESSION_AUTH',
@@ -46,6 +47,7 @@ module.exports = {
             'username',
             'payload',
             'inputFields',
+            'fullResponse',
         ],
         // subset of SENSITIVE_FIELDS
         OBJECT_FIELDS: [

--- a/services/secret-service/src/constant/index.js
+++ b/services/secret-service/src/constant/index.js
@@ -47,11 +47,8 @@ module.exports = {
             'username',
             'payload',
             'inputFields',
-<<<<<<< HEAD
             'fullResponse',
-=======
             'consumerSecret',
->>>>>>> master
         ],
         // subset of SENSITIVE_FIELDS
         OBJECT_FIELDS: [

--- a/services/secret-service/src/model/AuthClient/index.js
+++ b/services/secret-service/src/model/AuthClient/index.js
@@ -143,6 +143,8 @@ module.exports = {
                 default: false,
             },
             predefinedScope: String,
+            username: String,
+            password: String,
         })),
     [SESSION_AUTH]:
         AuthClient.discriminator(`A_${SESSION_AUTH}`, new Schema({

--- a/services/secret-service/src/model/AuthClient/index.js
+++ b/services/secret-service/src/model/AuthClient/index.js
@@ -130,8 +130,14 @@ module.exports = {
         })),
     [OA2_PASSWORD]:
         AuthClient.discriminator(`A_${OA2_PASSWORD}`, new Schema({
-            clientId: String,
-            clientSecret: String,
+            clientId: {
+                type: String,
+                required: true,
+            },
+            clientSecret: {
+                type: String,
+                required: true,
+            },
             endpoints: {
                 token: {
                     type: String,

--- a/services/secret-service/src/model/AuthClient/index.js
+++ b/services/secret-service/src/model/AuthClient/index.js
@@ -8,6 +8,7 @@ const {
     OA1_THREE_LEGGED,
     OA2_AUTHORIZATION_CODE,
     SESSION_AUTH,
+    OA2_PASSWORD,
 } = require('../../constant').AUTH_TYPE;
 
 const { Schema } = mongoose;
@@ -124,6 +125,22 @@ module.exports = {
                 userinfo: String,
                 revocation: String,
                 endSession: String,
+            },
+            predefinedScope: String,
+        })),
+    [OA2_PASSWORD]:
+        AuthClient.discriminator(`A_${OA2_PASSWORD}`, new Schema({
+            clientId: String,
+            clientSecret: String,
+            endpoints: {
+                token: {
+                    type: String,
+                    required: true,
+                },
+            },
+            includeCredentialsInHeader: {
+                type: Boolean,
+                default: false,
             },
             predefinedScope: String,
         })),

--- a/services/secret-service/src/model/Secret/index.js
+++ b/services/secret-service/src/model/Secret/index.js
@@ -207,7 +207,7 @@ module.exports = {
             expires: String,
             refreshToken: String,
             scope: String,
-            fullResponse: Schema.Types.Mixed,
+            fullResponse: String,
         },
     })),
 };

--- a/services/secret-service/src/model/Secret/index.js
+++ b/services/secret-service/src/model/Secret/index.js
@@ -11,6 +11,7 @@ const {
     OA1_THREE_LEGGED,
     OA2_AUTHORIZATION_CODE,
     SESSION_AUTH,
+    OA2_PASSWORD,
 } = AUTH_TYPE;
 
 const { Schema } = mongoose;
@@ -176,5 +177,37 @@ module.exports = {
             externalId: String,
         },
     })),
-
+    [OA2_PASSWORD]: Secret.discriminator(`S_${OA2_PASSWORD}`, new Schema({
+        value: {
+            authClientId: {
+                type: Schema.Types.ObjectId,
+                required: true,
+                validate: {
+                    validator: (v) => new Promise((resolve) => {
+                        AuthClient.full.findOne({ _id: v }, (err, doc) => {
+                            if (err || !doc) {
+                                resolve(false);
+                            } else {
+                                resolve(true);
+                            }
+                        });
+                    }),
+                    // Default error message, overridden by 2nd argument to `cb()` above
+                    message: 'Auth client is not existing',
+                },
+            },
+            accessToken: {
+                type: String,
+                required: true,
+            },
+            tokenType: {
+                type: String,
+                required: true,
+            },
+            expires: String,
+            refreshToken: String,
+            scope: String,
+            fullResponse: Schema.Types.Mixed,
+        },
+    })),
 };

--- a/services/secret-service/src/route/auth-clients/index.js
+++ b/services/secret-service/src/route/auth-clients/index.js
@@ -14,7 +14,6 @@ const { ROLE, ENTITY_TYPE, AUTH_TYPE } = require('../../constant');
 const authFlowManager = require('../../auth-flow-manager');
 const Pagination = require('../../util/pagination');
 const { OA2_AUTHORIZATION_CODE, OA2_PASSWORD } = require('../../constant').AUTH_TYPE;
-const handleOAuth2Password = require('../callback/handle-oauth2-password');
 
 const log = logger.getLogger(`${conf.log.namespace}/auth-client`);
 
@@ -256,45 +255,6 @@ class AuthClientRouter {
                         authUrl,
                     },
                 });
-            } catch (err) {
-                log.error(err);
-                next({
-                    err,
-                    status: 400,
-                    message: err.message,
-                });
-            }
-        });
-
-        this.router.post('/:id/get-token', getKeyParameter, jsonParser, async (req, res, next) => {
-            const authClient = await AuthClientDAO.findOne({ _id: req.params.id });
-            const data = req.body.data ? req.body.data : req.body;
-            const creator = req.user.sub;
-
-            try {
-                if (authClient.type !== AUTH_TYPE.OA2_PASSWORD) {
-                    return next({
-                        status: 405,
-                        message: 'get-token endpoint is only valid for OA2_PASSWORD auth clients',
-                    });
-                }
-
-                const { username, password, scope } = data;
-
-                if (!username || !password) {
-                    throw new Error('Username and password are required');
-                }
-
-                const response = await handleOAuth2Password({
-                    req,
-                    authClient,
-                    username,
-                    password,
-                    scope,
-                    creator,
-                });
-
-                res.send(response);
             } catch (err) {
                 log.error(err);
                 next({

--- a/services/secret-service/src/route/auth-clients/index.js
+++ b/services/secret-service/src/route/auth-clients/index.js
@@ -14,6 +14,7 @@ const { ROLE, ENTITY_TYPE, AUTH_TYPE } = require('../../constant');
 const authFlowManager = require('../../auth-flow-manager');
 const Pagination = require('../../util/pagination');
 const { OA2_AUTHORIZATION_CODE } = require('../../constant').AUTH_TYPE;
+const handleOAuth2Password = require('../callback/handle-oauth2-password');
 
 const log = logger.getLogger(`${conf.log.namespace}/auth-client`);
 
@@ -248,6 +249,45 @@ class AuthClientRouter {
                         authUrl,
                     },
                 });
+            } catch (err) {
+                log.error(err);
+                next({
+                    err,
+                    status: 400,
+                    message: err.message,
+                });
+            }
+        });
+
+        this.router.post('/:id/get-token', getKeyParameter, jsonParser, async (req, res, next) => {
+            const authClient = await AuthClientDAO.findOne({ _id: req.params.id });
+            const data = req.body.data ? req.body.data : req.body;
+            const creator = req.user.sub;
+
+            try {
+                if (authClient.type !== AUTH_TYPE.OA2_PASSWORD) {
+                    return next({
+                        status: 405,
+                        message: 'get-token endpoint is only valid for OA2_PASSWORD auth clients',
+                    });
+                }
+
+                const { username, password, scope } = data;
+
+                if (!username || !password) {
+                    throw new Error('Username and password are required');
+                }
+
+                const response = await handleOAuth2Password({
+                    req,
+                    authClient,
+                    username,
+                    password,
+                    scope,
+                    creator,
+                });
+
+                res.send(response);
             } catch (err) {
                 log.error(err);
                 next({

--- a/services/secret-service/src/route/auth-clients/index.js
+++ b/services/secret-service/src/route/auth-clients/index.js
@@ -13,7 +13,7 @@ const conf = require('../../conf');
 const { ROLE, ENTITY_TYPE, AUTH_TYPE } = require('../../constant');
 const authFlowManager = require('../../auth-flow-manager');
 const Pagination = require('../../util/pagination');
-const { OA2_AUTHORIZATION_CODE } = require('../../constant').AUTH_TYPE;
+const { OA2_AUTHORIZATION_CODE, OA2_PASSWORD } = require('../../constant').AUTH_TYPE;
 const handleOAuth2Password = require('../callback/handle-oauth2-password');
 
 const log = logger.getLogger(`${conf.log.namespace}/auth-client`);
@@ -26,6 +26,13 @@ const authClientObfuscator = {
         ...value,
         clientId: '***',
         clientSecret: '***',
+    }),
+
+    [OA2_PASSWORD]: (value) => ({
+        ...value,
+        clientId: '***',
+        clientSecret: '***',
+        password: '***',
     }),
 };
 

--- a/services/secret-service/src/route/callback/handle-oauth.js
+++ b/services/secret-service/src/route/callback/handle-oauth.js
@@ -8,7 +8,6 @@ const authFlowManager = require('../../auth-flow-manager');
 const conf = require('../../conf');
 const { getKey } = require('../../middleware/key');
 
-
 const log = logger.getLogger(`${conf.log.namespace}/callback/handle-oauth2`);
 
 module.exports = async function handleOAuth({

--- a/services/secret-service/src/route/callback/handle-oauth2-password.js
+++ b/services/secret-service/src/route/callback/handle-oauth2-password.js
@@ -2,9 +2,7 @@ const moment = require('moment');
 const authFlowManager = require('../../auth-flow-manager');
 const AuthClientDAO = require('../../dao/auth-client');
 
-module.exports = async function handleOAuth2Password({
-    data,
-}) {
+module.exports = async function handleOAuth2Password(data) {
     const {
         authClientId, username, password, scope, name,
     } = data;
@@ -48,7 +46,7 @@ module.exports = async function handleOAuth2Password({
             expires,
             refreshToken: refresh_token,
             scope: returnedScope,
-            fullResponse: response,
+            fullResponse: JSON.stringify(response),
         },
     };
 };

--- a/services/secret-service/src/route/callback/handle-oauth2-password.js
+++ b/services/secret-service/src/route/callback/handle-oauth2-password.js
@@ -15,7 +15,7 @@ module.exports = async function handleOAuth2Password(data) {
 
     const resolvedUsername = username || authClient.username;
     const resolvedPassword = password || authClient.password;
-    const resolvedScope = scope || authClient.scope;
+    const resolvedScope = scope || authClient.predefinedScope;
 
     const response = await authFlowManager.exchangeRequestPasswordFlow({
         authClient,

--- a/services/secret-service/src/route/callback/handle-oauth2-password.js
+++ b/services/secret-service/src/route/callback/handle-oauth2-password.js
@@ -1,0 +1,101 @@
+const moment = require('moment');
+const find = require('lodash/find');
+const logger = require('@basaas/node-logger');
+const authFlowManager = require('../../auth-flow-manager');
+const SecretDAO = require('../../dao/secret');
+const { ROLE } = require('../../constant');
+const conf = require('../../conf');
+const { getKey } = require('../../middleware/key');
+
+const log = logger.getLogger(`${conf.log.namespace}/callback/handle-oauth2`);
+
+module.exports = async function handleOAuth2Password({
+    req,
+    authClient,
+    username,
+    password,
+    scope,
+    creator,
+}) {
+    const response = await authFlowManager.exchangeRequestPasswordFlow({
+        authClient, username, password, scope,
+    });
+
+    if (response.error || !response.access_token) {
+        throw new Error(`Failed to get token: ${response.error || 'No token received'}`);
+    }
+
+    let modifiedSecret = null;
+    // fetch key
+    const key = await getKey(req);
+
+    const {
+        access_token, token_type, expires_in, refresh_token, scope: returnedScope,
+    } = response;
+
+    const expires = (expires_in !== undefined && !Number.isNaN(expires_in))
+        ? moment().add(expires_in, 'seconds').format() : moment(1e15).format();
+
+    let secret = {
+        owners: [{
+            id: creator,
+            type: ROLE.USER,
+        }],
+        type: authClient.type,
+        value: {
+            authClientId: authClient._id,
+            accessToken: access_token,
+            tokenType: token_type,
+            expires,
+            refreshToken: refresh_token,
+            scope: returnedScope,
+            fullResponse: response,
+        },
+    };
+
+    secret = await authFlowManager.preprocessSecret({
+        authClient,
+        secret,
+        tokenResponse: response,
+        localMiddleware: req.app.locals.middleware,
+    });
+
+    // try to find secret by external id to prevent duplication
+    const _secret = await SecretDAO.findByExternalId(
+        secret.value.externalId,
+        authClient._id,
+    );
+
+    if (_secret) {
+        const updateValues = {
+            id: _secret._id,
+            data: {
+                value: {
+                    scope: returnedScope,
+                    expires,
+                    refreshToken: refresh_token,
+                    accessToken: access_token,
+                },
+            },
+        };
+
+        if (!find(_secret.owners, { id: creator })) {
+            updateValues.data.owners = _secret.owners;
+            updateValues.data.owners.push({
+                id: creator,
+                type: ROLE.USER,
+            });
+        }
+
+        modifiedSecret = await SecretDAO.update(updateValues, key);
+    } else {
+        // create new secret
+        modifiedSecret = await SecretDAO.create(secret, key);
+    }
+
+    return {
+        data: {
+            secretId: modifiedSecret._id,
+        },
+    };
+};

--- a/services/secret-service/src/route/callback/handle-oauth2.js
+++ b/services/secret-service/src/route/callback/handle-oauth2.js
@@ -9,7 +9,6 @@ const authFlowManager = require('../../auth-flow-manager');
 const conf = require('../../conf');
 const { getKey } = require('../../middleware/key');
 
-
 const log = logger.getLogger(`${conf.log.namespace}/callback/handle-oauth2`);
 
 module.exports = async function handleOAuth2({

--- a/services/secret-service/src/route/callback/index.js
+++ b/services/secret-service/src/route/callback/index.js
@@ -12,7 +12,6 @@ const log = logger.getLogger(`${conf.log.namespace}/callback`, {
 
 const router = express.Router();
 
-
 router.get('/', async (req, res, next) => {
     try {
         const queryObject = qs.parse(url.parse(req.originalUrl).query);


### PR DESCRIPTION
**What has changed?**

- Addition of new auth client type for OAuth2 Password flows
- Additon of new secret type for OAuth2 Password flows
- Updated OpenAPI docs for the new auth client and secret types

**Details**

`POST` request to `/auth-clients` endpoint to generate OAuth2 Password auth client
```json
{
    "name": "OA2 Password Test Client, creds in ac",
    "type": "OA2_PASSWORD",
    "clientId": "abc123",
    "clientSecret": "def456",
    "endpoints": {
      "token": "https://company1.sandbox.my.salesforce.com/services/oauth2/token"
    },
    "includeCredentialsInHeader": false,
    "username": "user123",  // optional
    "password": "uncrackable2" // optional
  }
```

Response:
```json
{
    "data": {
        "clientId": "***", // data is masked in response and in context of listing all secrets
        "clientSecret": "***",
        "endpoints": {
            "token": "https://company1.sandbox.my.salesforce.com/services/oauth2/token"
        },
        "includeCredentialsInHeader": false,
        "username": "idinteractive.user@harman.com.uat",
        "password": "***",
        "_id": "66919418503b5dd585f7c802",
        "name": "OA2 Password Test Client",
        "owners": [
            {
                "id": "66859956557cfc511d4000aa",
                "type": "USER"
            }
        ],
        "type": "OA2_PASSWORD",
        "__t": "A_OA2_PASSWORD",
        "createdAt": "2024-07-12T20:37:44.511Z",
        "updatedAt": "2024-07-12T20:37:44.511Z",
        "__v": 0
    }
}
```

`POST` request to `/secrets` endpoint to generate a secret:

```json
{
  "authClientId": "66919418503b5dd585f7c802",
  "name": "OA2 Pass Secret Test",
  "type": "OA2_PASSWORD",
  "username": "user123", // if not provided to auth client, or if override is desired
  "password": "uncrackable2", // if not provided to auth client, or if override is desired
}
```

Upon receipt of the secret generation request, the Secret Service will use the combined info from the auth client and the secret to make an OAuth2 Password request to the token endpoint specified in the auth client. The acccess token will be encrypted and stored in the secret.

Response - note that the JSON stringified full response from the access token endpoint is saved. This allows flows to make use of non-standard fields in the response if necessary. When the secret it fetched individually the encrypted fields will be decrypted (following the same pattern as other auth client flows):
```json
{
    "data": {
        "value": {
            "authClientId": "66919418503b5dd585f7c802",
            "accessToken":"bÉ©«!èF?G³§]:¤8þaf'¢é$¿Mu\bÂñåsxØuô2Ü½ñ\f/5øÈj-êºl%ÝÏö a°(ð¨1®\u000br^Ól« `RíC§Í»ù»ñ>Ø|ät´®LR¤2ºP×D\f",
            "tokenType": "Bearer",
            "expires": "33658-09-27T01:46:40+00:00",
            "fullResponse":"CnZjêõ©Q9JÙIq¢òm¯$\u000bãÃeFòO§ü¾G^Þùe¨¥h¯BÏ¾É\f×Å³vì^K7Q÷iJ,T%\rÇQ¡XA[° $]_ýÞAê0gí oîè>øburäÊUp*wQ4÷Ç$¿ÔçM}\sà}«ZUÍ^Ïóé^8Ï_>Ø¯Çoo¬ügÀ¬°iTÒcLCÓI=&ê;h(2[í\\±$ù/lºqRs7âÍVz}.Qu#wíh_¶e+1R¶P Å\u000bW÷ þ\ts¬ç»ÓÖú2g\r'P¬ý¨þsÇgÎõ,°Î\fám©ò9D¥øéjµñ¥Î;C¤S#w.T{AÎ,¢Ù|W0"
        },
        "_id": "6691942f503b5dd585f7c805",
        "name": "OA2 Pass Secret Test",
        "owners": [
            {
                "id": "66859956557cfc511d4150db",
                "type": "USER"
            }
        ],
        "type": "OA2_PASSWORD",
        "encryptedFields": [
            "accessToken",
            "fullResponse"
        ],
        "__t": "S_OA2_PASSWORD",
        "createdAt": "2024-07-12T20:38:07.817Z",
        "updatedAt": "2024-07-12T20:38:07.817Z",
        "__v": 0
    }
}
```

**Does a specific change require especially careful review?**

No

**What is still open or a known issue?**

The OAuth2 Password flow does not typically have a refresh token (tokens do not expire), so refresh functionality is not currently enabled.

**Release Notes**

Adds support for OAuth2 Password authentication
