### PR TITLE
Add missing dead letter queue for Component Orchestrator back channel message queue

### DIFF
--- a/services/component-orchestrator/src/queues-manager/RabbitMqQueuesManager.js
+++ b/services/component-orchestrator/src/queues-manager/RabbitMqQueuesManager.js
@@ -44,6 +44,12 @@ class RabbitMqQueuesManager extends QueuesManager {
             BACKCHANNEL_EXCHANGE,
             BACKCHANNEL_DEAD_LETTER_KEY
         );
+        const BACKCHANNEL_DEAD_LETTER_QUEUE = `${BACKCHANNEL_EXCHANGE}:deadletter`;
+        await this._queueCreator.assertMessagesQueue(
+            BACKCHANNEL_DEAD_LETTER_QUEUE,
+            BACKCHANNEL_EXCHANGE
+        );
+        await this._queueCreator.bindQueue(BACKCHANNEL_DEAD_LETTER_QUEUE, BACKCHANNEL_EXCHANGE, BACKCHANNEL_DEAD_LETTER_KEY);
         await this._queueCreator.bindQueue(BACKCHANNEL_MESSAGES_QUEUE, BACKCHANNEL_EXCHANGE, BACKCHANNEL_INPUT_KEY);
         await this._queueCreator.bindQueue(BACKCHANNEL_MESSAGES_QUEUE, BACKCHANNEL_EXCHANGE, BACKCHANNEL_STATE_KEY);
         await this._queueCreator.bindQueue(BACKCHANNEL_ERROR_QUEUE, BACKCHANNEL_EXCHANGE, BACKCHANNEL_ERROR_KEY);


### PR DESCRIPTION
Add dead letter queue and binding for backchannel messages in RabbitMqQueuesManager

**What has changed?**

- There is a dead letter queue key but it is an uncountable message. This adds a queue for those messages so that they can be handled. It also creates a general awareness of messages failing to process in the component orchestrator between component steps

**Does a specific change require especially careful review?**

N/A

**What is still open or a known issue?**

**Release Notes**
Added the missing dead letter queue for the component orchestrator backchannel queue
