### PR TITLE
Allow Multiple Auth Client Owners

### DIFF
--- a/services/secret-service/src/route/auth-clients/index.js
+++ b/services/secret-service/src/route/auth-clients/index.js
@@ -98,14 +98,18 @@ class AuthClientRouter {
         this.router.post('/', async (req, res, next) => {
             const data = req.body.data ? req.body.data : req.body;
             try {
+                const owners = [{
+                    id: req.user.sub.toString(),
+                    type: ENTITY_TYPE.USER,
+                }];
+                if (data.owners) {
+                    owners.push(...data.owners.filter((owner) => owner.id !== req.user.sub.toString()));
+                }
                 res.send({
                     data: maskAuthClient({
                         authClient: await AuthClientDAO.create({
                             ...data,
-                            owners: [{
-                                id: req.user.sub.toString(),
-                                type: ENTITY_TYPE.USER,
-                            }],
+                            owners,
                             tenant: req.user.tenant,
                         }),
                         requester: req.user,


### PR DESCRIPTION
**What has changed?**
- Auth clients can now have multiple owners - If an owners array is passed in the original POST request to create an auth client then those owners will be added to the owners array

**Does a specific change require especially careful review?**
No

**Release Notes**
- Allow auth clients to have more than one owner at create time
