### PR TITLE
DOO 511: Refresh OAuth Client Credentials

### DIFF
--- a/services/secret-service/src/auth-flow-manager/index.js
+++ b/services/secret-service/src/auth-flow-manager/index.js
@@ -397,7 +397,7 @@ module.exports = {
                 scope: authClient.predefinedScope,
                 customFields: authClient.customFields ? Object.fromEntries(authClient.customFields) : {},
                 includeCredentialsInHeader: authClient.includeCredentialsInHeader,
-                inputFields: secret.value.inputFields || {}
+                inputFields: secret.value.inputFields || {},
             });
         }
         default:

--- a/services/secret-service/src/dao/secret.js
+++ b/services/secret-service/src/dao/secret.js
@@ -219,7 +219,8 @@ module.exports = {
         // refresh secrets with refreshToken only
         let _secret = secret;
         if ((secret.type === OA2_AUTHORIZATION_CODE && secret.value.refreshToken)
-            || (secret.type === SESSION_AUTH)) {
+            || (secret.type === SESSION_AUTH)
+            || (secret.type === OA2_CLIENT_CREDENTIALS)) {
             _secret = await refresh(secret, key);
         }
         // exclude extra sensitive values


### PR DESCRIPTION
**What has changed?**
Adds `OA2_CLIENT_CREDENTIALS` to secret types that attempt a refresh

**Does a specific change require especially careful review?**
Just needs to verify that OA2_CLIENT_CREDENTIALS secret flow works / refreshes

**What is still open or a known issue?**
NA

**Release Notes**

- Fix bug in OA2_CLIENT_CREDENTIALS refresh functionality