### PR TITLE
DOO 534: Fix Spelling of Schedule

### DIFF
--- a/services/scheduler/src/SchedulePublisher.js
+++ b/services/scheduler/src/SchedulePublisher.js
@@ -9,7 +9,7 @@ class OIH_SchedulePublisher extends SchedulePublisher {
   }
   async scheduleFlow(flow) {
     const interval = cronParser.parseExpression(flow.cron);
-    const nextSheduledTimestamp = interval.next();
+    const nextScheduledTimestamp = interval.next();
     const event = new Event({
       headers: {
         name: 'flow.execute',
@@ -19,8 +19,8 @@ class OIH_SchedulePublisher extends SchedulePublisher {
         flow,
         msg: {
           data: {
-            sheduledTimestamp: new Date().toISOString(),
-            nextSheduledTimestamp,
+            scheduledTimestamp: new Date().toISOString(),
+            nextScheduledTimestamp,
           },
           metadata: {
             source: {


### PR DESCRIPTION
**What has changed?**

- The spelling of `scheduledTimestamp` and `nextScheduledTimestamp` have been corrected

**Does a specific change require especially careful review?**

- There are no further references to these variables in this repo, but any external code that relies on them must be updated accordingly

**What is still open or a known issue?**

- Nothing

**Release Notes**

- The spelling of `scheduledTimestamp` and `nextScheduledTimestamp` have been corrected
